### PR TITLE
Add `global-block` to the list of supported rejection reasons

### DIFF
--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -79,6 +79,7 @@ data MandrillRejectReason = RR_HardBounce
     | RR_TestModeLimit
     | RR_Unsigned
     | RR_Rule
+    | RR_GlobalBlock
     deriving Show
 
 deriveJSON defaultOptions {


### PR DESCRIPTION
See [#1413](https://github.com/centralapp/cosmos/issues/1413).
